### PR TITLE
For v1

### DIFF
--- a/MSLSP_Functions.r
+++ b/MSLSP_Functions.r
@@ -1995,6 +1995,9 @@ CreateProduct <- function(yr,productFile, qaFile, productTable, baseImage, water
 
     if (lyr$units == 'Day of year') {data <- data - startDate}    #If units are Day of year, convert from date to day of year
     
+    if (lyr$short_name == 'EVImax' | lyr$short_name == 'EVIamp'| lyr$short_name == 'EVImax_2' | lyr$short_name == 'EVIamp_2') {
+      data[data > 10000] <- 10000      #Set as 10000 for the pixels where EVImax or EVIamp exceed 10000
+    }
     
     data[data < -32767 | data > 32767] <- 32767      #Ensure no values are outside the range
     ncvar_put(ncFile,results[[i+1]], data)           #Now put the image into the file

--- a/MSLSP_Functions.r
+++ b/MSLSP_Functions.r
@@ -1978,6 +1978,28 @@ CreateProduct <- function(yr,productFile, qaFile, productTable, baseImage, water
   # Now create the netCDF file with the defined variables
   ncFile <- nc_create(productFile,results,force_v4=T)
   
+  
+  # Assign NA for the EVImax, EVIamp, and EVIare layers where their values exceed 10000, 10000, and 32766, respectively, 
+  # and give 6 (i.e., "No cycles detected") for the pixels in all layers
+  ngEVI <- matrix(0, dim(baseImage)[1], dim(baseImage)[2])           # A layer to screen all pixels having bad EVI values
+    
+  for (i in 1:length(lyrs$short_name)) {
+    lyr <- lyrs[i,]
+    
+    if (lyr$short_name == 'EVImax' | lyr$short_name == 'EVIamp'| lyr$short_name == 'EVImax_2' | lyr$short_name == 'EVIamp_2') {
+      data <- readLyrChunks(lyr$calc_lyr, yr, numChunks, numPix, params$dirs$tempDir)
+      data <- matrix(data, dim(baseImage)[1], dim(baseImage)[2])           #Need to flip image for netcdf. The next lines do this
+      
+      ngEVI[data > 10000] <- 1      #Set as 1 for the pixels where EVImax or EVIamp exceed 10000
+      
+    }else if(lyr$short_name == 'EVIarea' | lyr$short_name == 'EVIarea_2'){
+      data <- readLyrChunks(lyr$calc_lyr, yr, numChunks, numPix, params$dirs$tempDir)
+      data <- matrix(data, dim(baseImage)[1], dim(baseImage)[2])           #Need to flip image for netcdf. The next lines do this
+
+      ngEVI[data > 32766] <- 1      #Set as 1 for the pixels where EVIare exceed 32766
+    }
+  }
+  
   #Loop through layers again, write the image data to the file
   for (i in 1:length(lyrs$short_name)) {
     lyr <- lyrs[i,]
@@ -1995,8 +2017,10 @@ CreateProduct <- function(yr,productFile, qaFile, productTable, baseImage, water
 
     if (lyr$units == 'Day of year') {data <- data - startDate}    #If units are Day of year, convert from date to day of year
     
-    if (lyr$short_name == 'EVImax' | lyr$short_name == 'EVIamp'| lyr$short_name == 'EVImax_2' | lyr$short_name == 'EVIamp_2') {
-      data[data > 10000] <- 10000      #Set as 10000 for the pixels where EVImax or EVIamp exceed 10000
+    if (lyr$short_name == 'overallQA' |lyr$short_name == 'overallQA_2' |lyr$short_name == 'gupQA' |lyr$short_name == 'gdownQA' |lyr$short_name == 'gupQA_2' |lyr$short_name == 'gdownQA_2'){
+      data[ngEVI == 1] <- 6 #Give 6 (i.e., "No cycle detected") for the pixels having bad EVI values 
+    }else{
+      data[ngEVI == 1] <- NA #Give NA for the pixels having bad EVI values 
     }
     
     data[data < -32767 | data > 32767] <- 32767      #Ensure no values are outside the range

--- a/MSLSP_Layers_v1.csv
+++ b/MSLSP_Layers_v1.csv
@@ -1,0 +1,136 @@
+calc_lyr,product_lyr,qa_lyr,short_name,long_name,units,scale,offset,data_type,valid_min,valid_max,fill_value,full_description
+1,1,,NumCycles,Number of phenological cycles,Number of cycles,1,0,Int16,0,6,32767,Number of phenological cycles detected during product year
+2,2,,OGI,Onset Greenness Increase (Date of 15% greenness increase),Day of year,1,0,Int16,-181,548,32767,Onset Greenness Increase (Date of 15% greenness increase)
+3,3,,50PCGI,50 Percent Greenness Increase (Date of 50% greenness increase) ,Day of year,1,0,Int16,-181,548,32767,50 Percent Greenness Increase (Date of 50% greenness increase) 
+4,4,,OGMx,Onset Greenness Maximum (Date of 90% greenness increase) ,Day of year,1,0,Int16,-181,548,32767,Onset Greenness Maximum (Date of 90% greenness increase) 
+5,,,Peak,Date of Cycle Peak,Day of year,1,0,Int16,1,366,32767,Date of Cycle Peak
+6,5,,OGD,Onset Greenness Decrease (Date of 10% greenness decrease) ,Day of year,1,0,Int16,-181,548,32767,Onset Greenness Decrease (Date of 10% greenness decrease) 
+7,6,,50PCGD,50 Percent Greenness Decrease (Date of 50% greenness decrease) ,Day of year,1,0,Int16,-181,548,32767,50 Percent Greenness Decrease (Date of 50% greenness decrease) 
+8,7,,OGMn,Onset Greenness Minimum (Date of 85% greenness decrease) ,Day of year,1,0,Int16,-181,548,32767,Onset Greenness Minimum (Date of 85% greenness decrease) 
+9,8,,EVImax,Maximum EVI2 during vegetation cycle,-,0.0001,0,Int16,0,10000,32767,Maximum EVI2 during vegetation cycle
+10,9,,EVIamp,EVI2 Amplitude during vegetation cycle ,-,0.0001,0,Int16,0,10000,32767,EVI2 Amplitude during vegetation cycle 
+11,10,,EVIarea,Integrated EVI2 during vegetation cycle ,-,0.01,0,Int16,32766,10000,32767,Integrated EVI2 during vegetation cycle 
+12,,,OGI_b2,OLI band 2 Reflectance [Onset Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Blue band reflectance on date of 15% greenness increase (OLI band 2, MSI band 2)"
+13,,,OGI_b3,OLI band 3  Reflectance [Onset Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Green band reflectance on date of 15% greenness increase (OLI band 3, MSI band 3)"
+14,,,OGI_b4,OLI band 4  Reflectance [Onset Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Red band reflectance on date of 15% greenness increase (OLI band 4, MSI band 4)"
+15,,,OGI_b5,OLI band 5  Reflectance [Onset Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"NIR band reflectance on date of 15% greenness increase (OLI band 5, MSI band 8A)"
+16,,,OGI_b6,OLI band 6  Reflectance [Onset Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"SWIR 1 band reflectance on date of 15% greenness increase (OLI band 6, MSI band 11)"
+17,,,OGI_b7,OLI band 7  Reflectance [Onset Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"SWIR 2 band reflectance on date of 15% greenness increase (OLI band 7, MSI band 12)"
+18,,,50PCGI_b2,OLI band 2 Reflectance [50 Percent Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Blue band reflectance on date of 50% greenness increase (OLI band 2, MSI band 2)"
+19,,,50PCGI_b3,OLI band 3  Reflectance [50 Percent Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Green band reflectance on date of 50% greenness increase (OLI band 3, MSI band 3)"
+20,,,50PCGI_b4,OLI band 4  Reflectance [50 Percent Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Red band reflectance on date of 50% greenness increase (OLI band 4, MSI band 4)"
+21,,,50PCGI_b5,OLI band 5  Reflectance [50 Percent Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"NIR band reflectance on date of 50% greenness increase (OLI band 5, MSI band 8A)"
+22,,,50PCGI_b6,OLI band 6  Reflectance [50 Percent Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"SWIR 1 band reflectance on date of 50% greenness increase (OLI band 6, MSI band 11)"
+23,,,50PCGI_b7,OLI band 7  Reflectance [50 Percent Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"SWIR 2 band reflectance on date of 50% greenness increase (OLI band 7, MSI band 12)"
+24,,,OGMx_b2,OLI band 2 Reflectance [Onset Greenness Maximum],Reflectance,0.0001,0,Int16,0,10000,32767,"Blue band reflectance on date of 90% greenness increase (OLI band 2, MSI band 2)"
+25,,,OGMx_b3,OLI band 3  Reflectance [Onset Greenness Maximum],Reflectance,0.0001,0,Int16,0,10000,32767,"Green band reflectance on date of 90% greenness increase (OLI band 3, MSI band 3)"
+26,,,OGMx_b4,OLI band 4  Reflectance [Onset Greenness Maximum],Reflectance,0.0001,0,Int16,0,10000,32767,"Red band reflectance on date of 90% greenness increase (OLI band 4, MSI band 4)"
+27,,,OGMx_b5,OLI band 5  Reflectance [Onset Greenness Maximum],Reflectance,0.0001,0,Int16,0,10000,32767,"NIR band reflectance on date of 90% greenness increase (OLI band 5, MSI band 8A)"
+28,,,OGMx_b6,OLI band 6  Reflectance [Onset Greenness Maximum],Reflectance,0.0001,0,Int16,0,10000,32767,"SWIR 1 band reflectance on date of 90% greenness increase (OLI band 6, MSI band 11)"
+29,,,OGMx_b7,OLI band 7  Reflectance [Onset Greenness Maximum],Reflectance,0.0001,0,Int16,0,10000,32767,"SWIR 2 band reflectance on date of 90% greenness increase (OLI band 7, MSI band 12)"
+30,,,Peak_b2,OLI band 2 Reflectance [Peak Greenness],Reflectance,0.0001,0,Int16,0,10000,32767,"Blue band reflectance on date of peak greenness (OLI band 2, MSI band 2)"
+31,,,Peak_b3,OLI band 3  Reflectance  [Peak Greenness],Reflectance,0.0001,0,Int16,0,10000,32767,"Green band reflectance on date of peak greenness  (OLI band 3, MSI band 3)"
+32,,,Peak_b4,OLI band 4  Reflectance  [Peak Greenness],Reflectance,0.0001,0,Int16,0,10000,32767,"Red band reflectance on date of peak greenness  (OLI band 4, MSI band 4)"
+33,,,Peak_b5,OLI band 5  Reflectance [Peak Greenness],Reflectance,0.0001,0,Int16,0,10000,32767,"NIR band reflectance on date of peak greenness  (OLI band 5, MSI band 8A)"
+34,,,Peak_b6,OLI band 6  Reflectance  [Peak Greenness],Reflectance,0.0001,0,Int16,0,10000,32767,"SWIR 1 band reflectance on date of peak greenness  (OLI band 6, MSI band 11)"
+35,,,Peak_b7,OLI band 7  Reflectance  [Peak Greenness],Reflectance,0.0001,0,Int16,0,10000,32767,"SWIR 2 band reflectance on date of peak greenness  (OLI band 7, MSI band 12)"
+36,,,OGD_b2,OLI band 2 Reflectance [Onset Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Blue band reflectance on date of 10% greenness decrease (OLI band 2, MSI band 2)"
+37,,,OGD_b3,OLI band 3  Reflectance [Onset Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Green band reflectance on date of 10% greenness decrease (OLI band 3, MSI band 3)"
+38,,,OGD_b4,OLI band 4  Reflectance [Onset Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Red band reflectance on date of 10% greenness decrease (OLI band 4, MSI band 4)"
+39,,,OGD_b5,OLI band 5  Reflectance [Onset Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"NIR band reflectance on date of 10% greenness decrease (OLI band 5, MSI band 8A)"
+40,,,OGD_b6,OLI band 6  Reflectance [Onset Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"SWIR 1 band reflectance on date of 10% greenness decrease (OLI band 6, MSI band 11)"
+41,,,OGD_b7,OLI band 7  Reflectance [Onset Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"SWIR 2 band reflectance on date of 10% greenness decrease (OLI band 7, MSI band 12)"
+42,,,50PCGD_b2,OLI band 2 Reflectance [50 Percent Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Blue band reflectance on date of 50% greenness decrease (OLI band 2, MSI band 2)"
+43,,,50PCGD_b3,OLI band 3  Reflectance [50 Percent Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Green band reflectance on date of 50% greenness decrease (OLI band 3, MSI band 3)"
+44,,,50PCGD_b4,OLI band 4  Reflectance [50 Percent Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Red band reflectance on date of 50% greenness decrease (OLI band 4, MSI band 4)"
+45,,,50PCGD_b5,OLI band 5  Reflectance [50 Percent Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"NIR band reflectance on date of 50% greenness decrease (OLI band 5, MSI band 8A)"
+46,,,50PCGD_b6,OLI band 6  Reflectance [50 Percent Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"SWIR 1 band reflectance on date of 50% greenness decrease (OLI band 6, MSI band 11)"
+47,,,50PCGD_b7,OLI band 7  Reflectance [50 Percent Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"SWIR 2 band reflectance on date of 50% greenness decrease (OLI band 7, MSI band 12)"
+48,,,OGMn_b2,OLI band 2 Reflectance [Onset Greenness Minimum],Reflectance,0.0001,0,Int16,0,10000,32767,"Blue band reflectance on date of 85% greenness decrease (OLI band 2, MSI band 2)"
+49,,,OGMn_b3,OLI band 3  Reflectance [Onset Greenness Minimum],Reflectance,0.0001,0,Int16,0,10000,32767,"Green band reflectance on date of 85% greenness decrease (OLI band 3, MSI band 3)"
+50,,,OGMn_b4,OLI band 4  Reflectance [Onset Greenness Minimum],Reflectance,0.0001,0,Int16,0,10000,32767,"Red band reflectance on date of 85% greenness decrease (OLI band 4, MSI band 4)"
+51,,,OGMn_b5,OLI band 5  Reflectance [Onset Greenness Minimum],Reflectance,0.0001,0,Int16,0,10000,32767,"NIR band reflectance on date of 85% greenness decrease (OLI band 5, MSI band 8A)"
+52,,,OGMn_b6,OLI band 6  Reflectance [Onset Greenness Minimum],Reflectance,0.0001,0,Int16,0,10000,32767,"SWIR 1 band reflectance on date of 85% greenness decrease (OLI band 6, MSI band 11)"
+53,,,OGMn_b7,OLI band 7  Reflectance [Onset Greenness Minimum],Reflectance,0.0001,0,Int16,0,10000,32767,"SWIR 2 band reflectance on date of 85% greenness decrease (OLI band 7, MSI band 12)"
+54,,1,gupNumObs,Number of days with observations during greenup,Number,1,0,Int16,0,32766,32767,-
+55,,2,gupMaxGap,Maximum time series gap during greenup, % of segment length,1,0,Int16,0,32766,32767,-
+56,,3,gupMaxGapCountSnow,"Maximum time series gap during greenup, but count snow as good ", % of segment length,1,0,Int16,0,32766,32767,-
+57,,4,gupMaxGapFilled,"Maximum time series gap during greenup, but count filled observations as good ", % of segment length,1,0,Int16,0,32766,32767,-
+58,,5,gupRsq,R squared during greenup,-,0.0001,0,Int16,0,32766,32767,-
+59,,6,gdownNumObs,Number of days with observations during greenup,Number,1,0,Int16,0,32766,32767,-
+60,,7,gdownMaxGap,Maximum time series gap during greendown, % of segment length,1,0,Int16,0,32766,32767,-
+61,,8,gdownMaxGapCountSnow,"Maximum time series gap during greendown, but count snow as good ", % of segment length,1,0,Int16,0,32766,32767,-
+62,,9,gdownMaxGapFilled,"Maximum time series gap during greendown, but count filled observations as good ", % of segment length,1,0,Int16,0,32766,32767,-
+63,,10,gdownRsq,R squared during greendown,-,0.0001,0,Int16,0,32766,32767,-
+64,11,,OGI_2,Cycle 2 - Onset Greenness Increase (Date of 15% greenness increase),Day of year,1,0,Int16,-181,548,32767,Cycle 2 - Onset Greenness Increase (Date of 15% greenness increase)
+65,12,,50PCGI_2,Cycle 2 - 50 Percent Greenness Increase (Date of 50% greenness increase) ,Day of year,1,0,Int16,-181,548,32767,Cycle 2 - 50 Percent Greenness Increase (Date of 50% greenness increase) 
+66,13,,OGMx_2,Cycle 2 - Onset Greenness Maximum (Date of 90% greenness increase) ,Day of year,1,0,Int16,-181,548,32767,Cycle 2 - Onset Greenness Maximum (Date of 90% greenness increase) 
+67,,,Peak_2,Cycle 2 - Date of Cycle Peak,Day of year,1,0,Int16,1,366,32767,Cycle 2- Date of Cycle Peak
+68,14,,OGD_2,Cycle 2 - Onset Greenness Decrease (Date of 10% greenness decrease) ,Day of year,1,0,Int16,-181,548,32767,Cycle 2 - Onset Greenness Decrease (Date of 10% greenness decrease) 
+69,15,,50PCGD_2,Cycle 2 - 50 Percent Greenness Decrease (Date of 50% greenness decrease) ,Day of year,1,0,Int16,-181,548,32767,Cycle 2 - 50 Percent Greenness Decrease (Date of 50% greenness decrease) 
+70,16,,OGMn_2,Cycle 2 - Onset Greenness Minimum (Date of 85% greenness decrease) ,Day of year,1,0,Int16,-181,548,32767,Cycle 2 - Onset Greenness Minimum (Date of 85% greenness decrease) 
+71,17,,EVImax_2,Cycle 2 - Maximum EVI2 during vegetation cycle,-,0.0001,0,Int16,0,10000,32767,Cycle 2 - Maximum EVI2 during vegetation cycle
+72,18,,EVIamp_2,Cycle 2 - EVI2 Amplitude during vegetation cycle ,-,0.0001,0,Int16,0,10000,32767,Cycle 2 - EVI2 Amplitude during vegetation cycle 
+73,19,,EVIarea_2,Cycle 2 - Integrated EVI2 during vegetation cycle ,-,0.01,0,Int16,0,32766,32767,Cycle 2 - Integrated EVI2 during vegetation cycle 
+74,,,OGI_b2_2,Cycle 2 - OLI band 2 Reflectance [Onset Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Blue band reflectance on date of 15% greenness increase (OLI band 2, MSI band 2)"
+75,,,OGI_b3_2,Cycle 2 - OLI band 3  Reflectance [Onset Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Green band reflectance on date of 15% greenness increase (OLI band 3, MSI band 3)"
+76,,,OGI_b4_2,Cycle 2 - OLI band 4  Reflectance [Onset Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Red band reflectance on date of 15% greenness increase (OLI band 4, MSI band 4)"
+77,,,OGI_b5_2,Cycle 2 - OLI band 5  Reflectance [Onset Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - NIR band reflectance on date of 15% greenness increase (OLI band 5, MSI band 8A)"
+78,,,OGI_b6_2,Cycle 2 - OLI band 6  Reflectance [Onset Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - SWIR 1 band reflectance on date of 15% greenness increase (OLI band 6, MSI band 11)"
+79,,,OGI_b7_2,Cycle 2 - OLI band 7  Reflectance [Onset Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - SWIR 2 band reflectance on date of 15% greenness increase (OLI band 7, MSI band 12)"
+80,,,50PCGI_b2_2,Cycle 2 - OLI band 2 Reflectance [50 Percent Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Blue band reflectance on date of 50% greenness increase (OLI band 2, MSI band 2)"
+81,,,50PCGI_b3_2,Cycle 2 - OLI band 3  Reflectance [50 Percent Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Green band reflectance on date of 50% greenness increase (OLI band 3, MSI band 3)"
+82,,,50PCGI_b4_2,Cycle 2 - OLI band 4  Reflectance [50 Percent Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Red band reflectance on date of 50% greenness increase (OLI band 4, MSI band 4)"
+83,,,50PCGI_b5_2,Cycle 2 - OLI band 5  Reflectance [50 Percent Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - NIR band reflectance on date of 50% greenness increase (OLI band 5, MSI band 8A)"
+84,,,50PCGI_b6_2,Cycle 2 - OLI band 6  Reflectance [50 Percent Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - SWIR 1 band reflectance on date of 50% greenness increase (OLI band 6, MSI band 11)"
+85,,,50PCGI_b7_2,Cycle 2 - OLI band 7  Reflectance [50 Percent Greenness Increase],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - SWIR 2 band reflectance on date of 50% greenness increase (OLI band 7, MSI band 12)"
+86,,,OGMx_b2_2,Cycle 2 - OLI band 2 Reflectance [Onset Greenness Maximum],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Blue band reflectance on date of 90% greenness increase (OLI band 2, MSI band 2)"
+87,,,OGMx_b3_2,Cycle 2 - OLI band 3  Reflectance [Onset Greenness Maximum],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Green band reflectance on date of 90% greenness increase (OLI band 3, MSI band 3)"
+88,,,OGMx_b4_2,Cycle 2 - OLI band 4  Reflectance [Onset Greenness Maximum],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Red band reflectance on date of 90% greenness increase (OLI band 4, MSI band 4)"
+89,,,OGMx_b5_2,Cycle 2 - OLI band 5  Reflectance [Onset Greenness Maximum],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - NIR band reflectance on date of 90% greenness increase (OLI band 5, MSI band 8A)"
+90,,,OGMx_b6_2,Cycle 2 - OLI band 6  Reflectance [Onset Greenness Maximum],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - SWIR 1 band reflectance on date of 90% greenness increase (OLI band 6, MSI band 11)"
+91,,,OGMx_b7_2,Cycle 2 - OLI band 7  Reflectance [Onset Greenness Maximum],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - SWIR 2 band reflectance on date of 90% greenness increase (OLI band 7, MSI band 12)"
+92,,,Peak_b2_2,Cycle 2 - OLI band 2 Reflectance [Peak Greenness],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Blue band reflectance on date of peak greenness (OLI band 2, MSI band 2)"
+93,,,Peak_b3_2,Cycle 2 - OLI band 3  Reflectance  [Peak Greenness],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Green band reflectance on date of peak greenness  (OLI band 3, MSI band 3)"
+94,,,Peak_b4_2,Cycle 2 - OLI band 4  Reflectance  [Peak Greenness],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Red band reflectance on date of peak greenness  (OLI band 4, MSI band 4)"
+95,,,Peak_b5_2,Cycle 2 - OLI band 5  Reflectance [Peak Greenness],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - NIR band reflectance on date of peak greenness  (OLI band 5, MSI band 8A)"
+96,,,Peak_b6_2,Cycle 2 - OLI band 6  Reflectance  [Peak Greenness],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - SWIR 1 band reflectance on date of peak greenness  (OLI band 6, MSI band 11)"
+97,,,Peak_b7_2,Cycle 2 - OLI band 7  Reflectance  [Peak Greenness],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - SWIR 2 band reflectance on date of peak greenness  (OLI band 7, MSI band 12)"
+98,,,OGD_b2_2,Cycle 2 - OLI band 2 Reflectance [Onset Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Blue band reflectance on date of 10% greenness decrease (OLI band 2, MSI band 2)"
+99,,,OGD_b3_2,Cycle 2 - OLI band 3  Reflectance [Onset Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Green band reflectance on date of 10% greenness decrease (OLI band 3, MSI band 3)"
+100,,,OGD_b4_2,Cycle 2 - OLI band 4  Reflectance [Onset Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Red band reflectance on date of 10% greenness decrease (OLI band 4, MSI band 4)"
+101,,,OGD_b5_2,Cycle 2 - OLI band 5  Reflectance [Onset Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - NIR band reflectance on date of 10% greenness decrease (OLI band 5, MSI band 8A)"
+102,,,OGD_b6_2,Cycle 2 - OLI band 6  Reflectance [Onset Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - SWIR 1 band reflectance on date of 10% greenness decrease (OLI band 6, MSI band 11)"
+103,,,OGD_b7_2,Cycle 2 - OLI band 7  Reflectance [Onset Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - SWIR 2 band reflectance on date of 10% greenness decrease (OLI band 7, MSI band 12)"
+104,,,50PCGD_b2_2,Cycle 2 - OLI band 2 Reflectance [50 Percent Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Blue band reflectance on date of 50% greenness decrease (OLI band 2, MSI band 2)"
+105,,,50PCGD_b3_2,Cycle 2 - OLI band 3  Reflectance [50 Percent Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Green band reflectance on date of 50% greenness decrease (OLI band 3, MSI band 3)"
+106,,,50PCGD_b4_2,Cycle 2 - OLI band 4  Reflectance [50 Percent Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Red band reflectance on date of 50% greenness decrease (OLI band 4, MSI band 4)"
+107,,,50PCGD_b5_2,Cycle 2 - OLI band 5  Reflectance [50 Percent Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - NIR band reflectance on date of 50% greenness decrease (OLI band 5, MSI band 8A)"
+108,,,50PCGD_b6_2,Cycle 2 - OLI band 6  Reflectance [50 Percent Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - SWIR 1 band reflectance on date of 50% greenness decrease (OLI band 6, MSI band 11)"
+109,,,50PCGD_b7_2,Cycle 2 - OLI band 7  Reflectance [50 Percent Greenness Decrease],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - SWIR 2 band reflectance on date of 50% greenness decrease (OLI band 7, MSI band 12)"
+110,,,OGMn_b2_2,Cycle 2 - OLI band 2 Reflectance [Onset Greenness Minimum],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Blue band reflectance on date of 85% greenness decrease (OLI band 2, MSI band 2)"
+111,,,OGMn_b3_2,Cycle 2 - OLI band 3  Reflectance [Onset Greenness Minimum],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Green band reflectance on date of 85% greenness decrease (OLI band 3, MSI band 3)"
+112,,,OGMn_b4_2,Cycle 2 - OLI band 4  Reflectance [Onset Greenness Minimum],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - Red band reflectance on date of 85% greenness decrease (OLI band 4, MSI band 4)"
+113,,,OGMn_b5_2,Cycle 2 - OLI band 5  Reflectance [Onset Greenness Minimum],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - NIR band reflectance on date of 85% greenness decrease (OLI band 5, MSI band 8A)"
+114,,,OGMn_b6_2,Cycle 2 - OLI band 6  Reflectance [Onset Greenness Minimum],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - SWIR 1 band reflectance on date of 85% greenness decrease (OLI band 6, MSI band 11)"
+115,,,OGMn_b7_2,Cycle 2 - OLI band 7  Reflectance [Onset Greenness Minimum],Reflectance,0.0001,0,Int16,0,10000,32767,"Cycle 2 - SWIR 2 band reflectance on date of 85% greenness decrease (OLI band 7, MSI band 12)"
+116,,11,gupNumObs_2,Number of days with observations during greenup,Number,1,0,Int16,0,32766,32767,-
+117,,12,gupMaxGap_2,Maximum time series gap during greenup, % of segment length,1,0,Int16,0,32766,32767,-
+118,,13,gupMaxGapCountSnow_2,"Maximum time series gap during greenup, but count snow as good ", % of segment length,1,0,Int16,0,32766,32767,-
+119,,14,gupMaxGapFilled_2,"Maximum time series gap during greenup, but count filled observations as good ", % of segment length,1,0,Int16,0,32766,32767,-
+120,,15,gupRsq_2,R squared during greenup,-,0.0001,0,Int16,0,32766,32767,-
+121,,16,gdownNumObs_2,Number of days with observations during greenup,Number,1,0,Int16,0,32766,32767,-
+122,,17,gdownMaxGap_2,Maximum time series gap during greendown, % of segment length,1,0,Int16,0,32766,32767,-
+123,,18,gdownMaxGapCountSnow_2,"Maximum time series gap during greendown, but count snow as good ", % of segment length,1,0,Int16,0,32766,32767,-
+124,,19,gdownMaxGapFilled_2,"Maximum time series gap during greendown, but count filled observations as good ", % of segment length,1,0,Int16,0,32766,32767,-
+125,,20,gdownRsq_2,R squared during greendown,-,0.0001,0,Int16,0,32766,32767,-
+126,,21,numObs,Number of days with clear observations in calendar year,Number,1,0,Int16,0,366,32767,Number of clear observations in calendar year
+127,,22,numObsCountSnow,Number of days with clear and snow filled observations in calendar year ,Number,1,0,Int16,0,366,32767,Number of clear and snow filled observations in calendar year 
+128,,23,maxGap,Maximum gap between clear obsevations in calendar year,Days,1,0,Int16,0,366,32767,Maximum gap between clear obsevations in calendar year
+129,,24,maxGapCountSnow,Maximum gap between clear or snow filled observations in calendar year,Days,1,0,Int16,0,366,32767,Maximum gap between clear or snow filled observations in calendar year
+,20,,gupQA,Quality Assurance for Greenup Segment,-,1,0,Int16,1,10,32767,Quality Assurance for Greenup Segment
+,21,,gdownQA,Quality Assurance for Greendown Segment,-,1,0,Int16,1,10,32767,Quality Assurance for Greendown Segment
+,22,,gupQA_2,Quality Assurance for Greenup Segment,-,1,0,Int16,1,10,32767,Quality Assurance for Greenup Segment
+,23,,gdownQA_2,Quality Assurance for Greendown Segment,-,1,0,Int16,1,10,32767,Quality Assurance for Greendown Segment
+,,,overallQA,Overall Quality Assurance for Cycle 1,,1,0,Int16,1,10,32767,Overall Quality Assurance for Cycle 1
+,,,overallQA_2,Overall Quality Assurance for Cycle 2,,1,0,Int16,1,10,32767,Overall Quality Assurance for Cycle 2

--- a/MSLSP_Parameters.json
+++ b/MSLSP_Parameters.json
@@ -82,7 +82,7 @@
     "maxDespikeIterations":50,   
     
     "splineBuffer":185,               
-    "splineSpar":0.4,   
+    "splineSpar":0.55,   
     
     "gapLengthToFill":20,  
     "maxWeight":0.5,                 


### PR DESCRIPTION
Hi Doug - I've made a few changes:

1. In the JSON file, charged "SplinePar" from 0.4 to 0.55. This is for consistency with the V0 product.
2. You may remember that there was an issue in the data range for EVImax, EVIamp, and EVIarea layers. They used to exceed 10000 for EVImax and EVIamp and 32766 for EVIarea layers in very few portions of data. We concluded that just assign NAs for the pixels in all the product layers, and then assign "No cycle detected" (for V0 it was #5, but I see that now it's #6) in the QA layers.
3. And the data layers file (CSV file) has been edited to give a shortened list of layers (i.e., the same layers we used in V0). And the valid range for EVIare has been changed (from 10000 to 32766).

In the meantime, I think I'm almost done with the V1 code quality check. It looks good. And I would say I agree with you that the gap-filling strategies for the V1 code, which make moderate differences between V0 and V1, especially EVI layers, are much more reasonable. Time series plots prove it! I'll share the results with Mark first next Monday. And then three of us can discuss at some point whether it's good to go for bulk running on AWS. Thanks!


